### PR TITLE
Fix README.md Typo in Prometheus Code Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Grafana and Prometheus are being deployed by Docker Swarm and the networking is 
       -  "traefik.frontend.rule=Host:grafana.localhost"
 
 **Prometheus Deployment**
+
     deploy:
       labels:
        - "traefik.frontend.rule=Host:prometheus.localhost"


### PR DESCRIPTION
Hi there,

I noticed a small typo in the readme, fixed it by adding missing newline to allow the Prometheus docker-compose code block to be displayed correctly.

Cheers