### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monitor Traefik with Prometheus
 
-This Repo helps you get started with monitoring [Traefik v2.0](https://traefik.io/)the amazing Reverse Proxy + so much more. Along with Traefik we will provision Prometheus for Time Series Data collection and Grafana for Visualization. Traefik will also act as a proxy in front of Promethues and Grafana while Prometheus monitors Traefik the other way. Cool, huh?
+This Repo helps you get started with monitoring [Traefik v2.0](https://traefik.io/)the amazing Reverse Proxy + so much more. Along with Traefik we will provision Prometheus for Time Series Data collection and Grafana for Visualization. Traefik will also act as a proxy in front of Prometheus and Grafana while Prometheus monitors Traefik the other way. Cool, huh?
 
 Before we can begin ensure you have Docker installed with Docker Swarm enabled. If you are using Docker for Desktop Mac or Windows you already have Swarm enabled. For all others please follow the [Swarm setup guide](https://docs.docker.com/engine/swarm/swarm-mode/).
 

--- a/cats.yml
+++ b/cats.yml
@@ -16,7 +16,7 @@ services:
         - "traefik.http.routers.cat-app.service=cat-app"
         - "traefik.http.services.cat-app.loadbalancer.server.port=5000"
         - "traefik.docker.network=inbound"
-        # Remove the line below to enable rate limiting. This will only allow avergae 1 request per second before erroring.
+        # Remove the line below to enable rate limiting. This will only allow average 1 request per second before erroring.
       #  - "traefik.http.routers.cat-app.middlewares=cat-app@docker"
       #  - "traefik.http.middlewares.cat-app.ratelimit.average=1"
 networks:


### PR DESCRIPTION
## Summary
- fix typo "Promethues" in README
- fix typo "avergae" in cats.yml comment

## Testing
- `docker-compose config` *(fails: command not found)*